### PR TITLE
Fixed repeating powerup sound bug

### DIFF
--- a/src/Level/Player.java
+++ b/src/Level/Player.java
@@ -458,7 +458,7 @@ public abstract class Player extends GameObject {
 	public void powerUp(MapEntity mapEntity) {
 		if (mapEntity instanceof MapTile) {
 			MapTile mapTile = (MapTile) mapEntity;
-			if (mapTile.getTileType() == TileType.POWER_UP) {
+			if (mapTile.getTileType() == TileType.POWER_UP && !hasPowerUp) {
 				hasPowerUp = true;
 				makeSound(powerUp);
 			}


### PR DESCRIPTION
The bug was fixed by adding a check to see if a powerup had been collected before playing powerup sound, preventing it from playing if the player already has one.