### PR TITLE
Lingering attack bug

### DIFF
--- a/src/Level/Player.java
+++ b/src/Level/Player.java
@@ -120,6 +120,11 @@ public abstract class Player extends GameObject {
 		else if (levelState == LevelState.PLAYER_DEAD) {
 			updatePlayerDead();
 		}
+		
+		// remove players fireball if it expires
+		if (currentFireball != null && currentFireball.getMapEntityStatus() == MapEntityStatus.REMOVED) {
+			currentFireball = null;
+		}
 	}
 
 	// add gravity to player, which is a downward force


### PR DESCRIPTION
Fixed bug that would cause the player's previous attack hitbox to stay active after the projectile had been removed from the screen.